### PR TITLE
Add `jupyterlab-browser-ai`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "jupyterlab>=4.5.0a3",
+    "jupyterlab-browser-ai>=0.1.1",
     "jupyterlite>=0.7.0a5",
     "jupyterlite-ai>=0.9.0a0",
     "jupyterlite-core>=0.7.0a5",

--- a/uv.lock
+++ b/uv.lock
@@ -683,6 +683,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jupyterlab-browser-ai"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyterlite-ai" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/8d/216dc541fa93fbe3322ca3b9453053b107ac9853cfa20e399a374f87975f/jupyterlab_browser_ai-0.1.1.tar.gz", hash = "sha256:cc72681aa14312c407612f26928136401361c6bfa1ebc323eba6181a877411b4", size = 194698, upload-time = "2025-09-22T14:22:57.78Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/f7/7359ae57686b7d57fe5e2844ba1e69d0bc3c7eca1bbad636d3895ae6c89f/jupyterlab_browser_ai-0.1.1-py3-none-any.whl", hash = "sha256:00972fbaa530db32b3b325e9b613a2ca4ad358d2048cb52e9a576967a776da36", size = 106671, upload-time = "2025-09-22T14:22:56.107Z" },
+]
+
+[[package]]
 name = "jupyterlab-cell-diff"
 version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1055,6 +1067,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "jupyterlab" },
+    { name = "jupyterlab-browser-ai" },
     { name = "jupyterlite" },
     { name = "jupyterlite-ai" },
     { name = "jupyterlite-core" },
@@ -1064,6 +1077,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "jupyterlab", specifier = ">=4.5.0a3" },
+    { name = "jupyterlab-browser-ai", specifier = ">=0.1.1" },
     { name = "jupyterlite", specifier = ">=0.7.0a5" },
     { name = "jupyterlite-ai", specifier = ">=0.9.0a0" },
     { name = "jupyterlite-core", specifier = ">=0.7.0a5" },


### PR DESCRIPTION
Add https://github.com/jtpio/jupyterlab-browser-ai

Currently `jupyterlab-brower-ai` only adds `ChromeAI`, but adding it to the development 